### PR TITLE
Revert "Bump nokogiri from 1.6.2.1 to 1.10.3 in /bootstrappers/chef/berks-cookbooks/cmake"

### DIFF
--- a/bootstrappers/chef/berks-cookbooks/cmake/Gemfile.lock
+++ b/bootstrappers/chef/berks-cookbooks/cmake/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     lumberjack (1.0.9)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile2 (2.4.0)
+    mini_portile (0.6.0)
     minitar (0.5.4)
     mixlib-authentication (1.3.0)
       mixlib-log
@@ -131,8 +131,8 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     nio4r (1.0.0)
-    nokogiri (1.10.3)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.6.2.1)
+      mini_portile (= 0.6.0)
     octokit (3.2.0)
       sawyer (~> 0.5.3)
     ohai (7.0.4)
@@ -237,7 +237,7 @@ PLATFORMS
 DEPENDENCIES
   berkshelf (~> 3.1.3)
   busser-serverspec (~> 0.2.6)
-  chef (~> 11.10)
+  chef (~> 11.12.8)
   chefspec (~> 3.4)
   foodcritic (~> 4.0.0)
   guard-rspec (~> 4.2.9)


### PR DESCRIPTION
Reverts kirillian/shiplane#22